### PR TITLE
Make changes to Docker Installation, including adding step by step in…

### DIFF
--- a/docs/fides/docs/installation/docker.md
+++ b/docs/fides/docs/installation/docker.md
@@ -1,9 +1,36 @@
 # Installation from Docker
 
-For the ease of deployment in production, the community releases a production-ready reference container image.
+Docker is a platform as a service that bundles software into containers, each of which contains everything the software needs to run, software, libraries, and configuration files. [Docker Hub](https://docs.docker.com/docker-hub/) makes it easy to manage container images.
 
-The fidesctl community releases Docker Images which are reference images for fidesctl. Every time a new version of fidesctl is released, the images are available in the [ethyca/fidesctl DockerHub](https://hub.docker.com/r/ethyca/fidesctl/tags). There are also mid-release versions (dirty versions) that get uploaded to DockerHub on every commit to the main branch.
+The fidesctl community releases a production-ready reference container image of fidesctl for the ease of deployment in production.
 
-These reference images contain all of the extras and dependencies for running the Python application. However they do not contain the required Postgres database.
+## Docker Hub Releases
 
-Fidesctl requires multiple components to function as it is a multi-part application. You may therefore also be interested in launching fidesctl in the Docker Compose environment, see: [Running Fidesctl in Docker](../quickstart/docker.md).
+The following is an overview of the fidesctl Docker Hub release process, including release cadence and what's included. 
+
+**Release Cadences**
+
+Every time a new version of fidesctl is released, the images are available in the [ethyca/fidesctl DockerHub](https://hub.docker.com/r/ethyca/fidesctl/tags).
+
+There are also mid-release versions (dirty versions) that get uploaded to DockerHub on every commit to the main branch. Implementation is not finalized in mid-release versions. 
+
+**What's Included**
+
+These reference images contain all of the extras and dependencies for running the Python application. However they do not contain the required Postgres database. Continue to [Setting up the database](./database.md).
+
+## Installation
+
+Install Docker and Docker Compose, then pull the latest container image from Docker Hub.
+
+1. Install `docker` locally (see [Docker Desktop](https://www.docker.com/products/docker-desktop) or your preferred installation). The minimum verified Docker version is `20.10.8`
+2. If your `docker` installation did not include `docker-compose`, make sure to get at least version `1.29.0`. Installation instructions can be found in the [Docker Compose documentation](https://docs.docker.com/compose/install/).
+3. Run `docker pull ethyca/fidesctl` to pull the latest fidesctl container image from Docker Hub.
+
+Congratulations! Fidesctl is now installed on your machine. 
+## Next Steps
+
+You're now ready to start enforcing privacy with Fidesctl! Below are suggestions for continuing your journey.
+
+- See  [Setting up the database](./database.md) to set up the Postgresql for fidesctl.
+- See [Running Fidesctl in Docker](../quickstart/docker.md) for more information on launching fidesctl in Docker Compose. Fidesctl requires multiple components to function as it is a multi-part application.
+- See the [Tutorial](../tutorial/index.md) for a hands-on guide that solves real data privacy problems by setting up a Fidesctl data privacy workflow.

--- a/docs/fides/docs/installation/docker.md
+++ b/docs/fides/docs/installation/docker.md
@@ -4,11 +4,19 @@ Docker is a platform as a service that bundles software into containers, each of
 
 The fidesctl community releases a production-ready reference container image of fidesctl for the ease of deployment in production.
 
+## Installation
+
+1. Install `docker` locally (see [Docker Desktop](https://www.docker.com/products/docker-desktop) or your preferred installation). The minimum verified Docker version is `20.10.8`.
+1. Confirm whether you have `docker-compose` using the command `docker-compose -v`. Make sure at least version `1.29.0` is installed. If your installation did not include `docker-compose`, installation instructions can be found in the [Docker Compose documentation](https://docs.docker.com/compose/install/).
+1. Run `docker pull ethyca/fidesctl` to pull the latest fidesctl container image from Docker Hub.
+
+Congratulations! Fidesctl is now installed on your machine. 
+
 ## Docker Hub Releases
 
 The following is an overview of the fidesctl Docker Hub release process, including release cadence and what's included. 
 
-**Release Cadences**
+**Release Cadence**
 
 Every time a new version of fidesctl is released, the images are available in the [ethyca/fidesctl DockerHub](https://hub.docker.com/r/ethyca/fidesctl/tags).
 
@@ -17,16 +25,6 @@ There are also mid-release versions (dirty versions) that get uploaded to Docker
 **What's Included**
 
 These reference images contain all of the extras and dependencies for running the Python application. However they do not contain the required Postgres database. Continue to [Setting up the database](./database.md).
-
-## Installation
-
-Install Docker and Docker Compose, then pull the latest container image from Docker Hub.
-
-1. Install `docker` locally (see [Docker Desktop](https://www.docker.com/products/docker-desktop) or your preferred installation). The minimum verified Docker version is `20.10.8`
-2. If your `docker` installation did not include `docker-compose`, make sure to get at least version `1.29.0`. Installation instructions can be found in the [Docker Compose documentation](https://docs.docker.com/compose/install/).
-3. Run `docker pull ethyca/fidesctl` to pull the latest fidesctl container image from Docker Hub.
-
-Congratulations! Fidesctl is now installed on your machine. 
 ## Next Steps
 
 You're now ready to start enforcing privacy with Fidesctl! Below are suggestions for continuing your journey.

--- a/docs/fides/docs/quickstart/docker.md
+++ b/docs/fides/docs/quickstart/docker.md
@@ -8,8 +8,7 @@ The recommended way to get Fidesctl running is via Docker. The following guide w
 
 Docker and Docker-Compose are the only requirements here.
 
-1. Install `docker` locally (see [Docker Desktop](https://www.docker.com/products/docker-desktop) or your preferred installation). The minimum verified Docker version is `20.10.8`
-1. If your `docker` installation did not include `docker-compose`, make sure to get at least version `1.29.0`. Installation instructions can be found [here](https://docs.docker.com/compose/install/).
+Follow the installation instructions in the [Installation with Docker](../installation/docker.md#installation) guide.
 
 ## Docker Setup
 


### PR DESCRIPTION
### Steps to Confirm

* Ran `make docs-serve` and checked changes locally 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [X] Documentation Updated :)

### Description Of Changes

I made some updates to the Docker Installation instructions. These include: 
- More information about Docker
- Installing Docker, Docker Compose
- Pulling the fidesctl container image
- Next steps for setting up the database, using Docker Compose, and following the tutorial

I went back and forth on whether to put "Installation" or "Docker Hub Releases" first. I think most developers would come to the page for those directions first, but the Docker Hub Releases section has important information as well.

I added "Implementation is not finalized in mid-release versions." based on past experience developing, to offer developers a bit of guidance on whether the "dirty versions" are safe to integrate against. But it is an educated guess. 
